### PR TITLE
Fix incorrect URL4 for no battery device.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -94,7 +94,7 @@ class FroniusHttp:
     #192.168.1.51/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DataCollection=CommonInverterData&DeviceId=1 
     
     #support for Fronius3.0-1 without Battery
-    URL4 = "/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData"
+    URL4 = "/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=CommonInverterData"
     PAC = ""
     UAC = ""                #Grid + solar consumption
     FAC = ""


### PR DESCRIPTION
Hello,

I have: Fronius Symo 4.5-3-M old link returned following error:
```
      "Status" : {
         "Code" : 6,
         "Reason" : "CGI-Args: Invalid parameter '' for attribute 'DeviceId' (must be numeric)",
         "UserMessage" : ""
      },
```

after changin URL4 you will get this:
```
      "Status" : {
         "Code" : 0,
         "Reason" : "",
         "UserMessage" : ""
      },
```

Plus bunch of inverter data. 
```
        "FAC" : {
            "Unit" : "Hz",
            "Value" : 49.979999999999997
         },
         "IAC" : {
            "Unit" : "A",
            "Value" : 10.4
         },
         "IDC" : {
            "Unit" : "A",
            "Value" : 7.75
         },
         "PAC" : {
            "Unit" : "W",
            "Value" : 2397
         },
         "TOTAL_ENERGY" : {
            "Unit" : "Wh",
            "Value" : 17482450
         },
         "UAC" : {
            "Unit" : "V",
            "Value" : 232.5
         },
         "UDC" : {
            "Unit" : "V",
            "Value" : 295.5
         },
```

I saw #1 but I did not read through it, sorry.
I just hope that this will solve that problem too.

BR.
jarzyn